### PR TITLE
Added sonatype repositories - to support Lift 2.6-SNAPSHOT

### DIFF
--- a/modules/artifact/src/main/scala/io/escalante/artifact/maven/MavenSettings.scala
+++ b/modules/artifact/src/main/scala/io/escalante/artifact/maven/MavenSettings.scala
@@ -56,6 +56,11 @@ class MavenSettings {
     // Add Typesafe repo
     enhancedRepos += TYPESAFE
 
+    // Add Sonatype, which holds latest Lift's jars
+    enhancedRepos += SONATYPE_SNAPSHOT
+    enhancedRepos += SONATYPE
+
+
     if (settings.getMirrors.size() == 0)
       return enhancedRepos ++ List()
 
@@ -90,6 +95,12 @@ object MavenSettings {
 
   private val TYPESAFE = new RemoteRepository(
     "typesafe", "default", "http://repo.typesafe.com/typesafe/maven-releases")
+
+  private val SONATYPE_SNAPSHOT = new RemoteRepository(
+    "sonatype-snapshot", "default", "http://oss.sonatype.org/content/repositories/snapshots")
+
+  private val SONATYPE = new RemoteRepository(
+    "sonatype", "default", "http://oss.sonatype.org/content/repositories/releases")
 
   private val ALT_USER_SETTINGS_XML_LOCATION = "org.apache.maven.user-settings"
 


### PR DESCRIPTION
Lift 2.6-SNAPSHOT jars are not on maven (not sure why), so escalante cannot find them if your app runs on 2.6.

I added the sonatype repos, hoping it will fix it.

I tried building this but I get

```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.1.3:script (scala-magic) on project escalante-assembly: Execution scala-magic of goal net.alchim31.maven:scala-maven-plugin:3.1.3:script failed. NullPointerException -> [Help 1]

```

Thanks

  Diego
